### PR TITLE
Add flink and beam example

### DIFF
--- a/examples/beam/pom.xml
+++ b/examples/beam/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.carbondata</groupId>
+    <artifactId>carbondata-parent</artifactId>
+    <version>1.0.0-incubating-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>carbondata-examples-beam</artifactId>
+  <name>Apache CarbonData :: Beam Examples</name>
+
+  <properties>
+    <dev.path>${basedir}/../../dev</dev.path>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-core</artifactId>
+      <version>0.3.0-incubating</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-io-hdfs</artifactId>
+      <version>0.3.0-incubating</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-hadoop</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-spark2</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src/main/scala</sourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.scala-tools</groupId>
+        <artifactId>maven-scala-plugin</artifactId>
+        <version>2.15.2</version>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <phase>compile</phase>
+          </execution>
+          <execution>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/examples/beam/src/main/scala/org/apache/carbondata/examples/BeamExample.scala
+++ b/examples/beam/src/main/scala/org/apache/carbondata/examples/BeamExample.scala
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.examples
+
+import java.io.File
+
+import org.apache.beam.sdk.Pipeline
+import org.apache.beam.sdk.io.hdfs.HDFSFileSource
+import org.apache.beam.sdk.options.PipelineOptionsFactory
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.sql.SparkSession
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.hadoop.{CarbonInputFormat, CarbonProjection}
+
+// Write carbondata file by spark and read it by flink
+// scalastyle:off println
+object BeamExample {
+  var spark: SparkSession = _
+
+  def main(args: Array[String]): Unit = {
+    // write carbondata file by spark
+    val path = writeCarbonFile("carbon_table")
+
+    // read two columns by beam
+    val conf = new Configuration()
+    val projection = new CarbonProjection
+    projection.addColumn("c1")  // column c1
+    projection.addColumn("c3")  // column c3
+    CarbonInputFormat.setColumnProjection(conf, projection)
+
+    val p = Pipeline.create(PipelineOptionsFactory.fromArgs(args).create())
+    val records = HDFSFileSource.readFrom(
+      path,
+      classOf[CarbonInputFormat[Array[Object]]],
+      classOf[Void],
+      classOf[Array[Object]]
+    )
+
+    p.run().waitUntilFinish()
+    println(records)
+
+    // delete carbondata file
+    cleanCarbonFile("carbon_table")
+  }
+
+  private def cleanCarbonFile(tableName: String): Unit = {
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
+  }
+
+  private def writeCarbonFile(tableName: String): String = {
+    val rootPath = new File(this.getClass.getResource("/").getPath
+        + "../../../..").getCanonicalPath
+    val storeLocation = s"$rootPath/examples/spark2/target/store"
+    val warehouse = s"$rootPath/examples/spark2/target/warehouse"
+    val metastoredb = s"$rootPath/examples/spark2/target/metastore_db"
+
+    CarbonProperties.getInstance()
+        .addProperty("carbon.kettle.home", s"$rootPath/processing/carbonplugins")
+        .addProperty("carbon.storelocation", storeLocation)
+        .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/MM/dd")
+
+    import org.apache.spark.sql.CarbonSession._
+
+    spark = SparkSession
+        .builder()
+        .master("local")
+        .appName("CarbonExample")
+        .enableHiveSupport()
+        .config("spark.sql.warehouse.dir", warehouse)
+        .config("javax.jdo.option.ConnectionURL",
+          s"jdbc:derby:;databaseName=$metastoredb;create=true")
+        .getOrCreateCarbonSession()
+
+    spark.sparkContext.setLogLevel("WARN")
+
+    spark.sql("DROP TABLE IF EXISTS carbon_table")
+
+    // Create table
+    spark.sql(
+      s"""
+         | CREATE TABLE $tableName(
+         |    shortField short,
+         |    intField int,
+         |    bigintField long,
+         |    doubleField double,
+         |    stringField string,
+         |    timestampField timestamp,
+         |    decimalField decimal(18,2),
+         |    dateField date,
+         |    charField char(5)
+         | )
+         | STORED BY 'carbondata'
+         | TBLPROPERTIES('DICTIONARY_INCLUDE'='dateField, charField')
+       """.stripMargin)
+
+    val path = s"$rootPath/examples/spark2/src/main/resources/data.csv"
+
+    spark.sql(
+      s"""
+         | LOAD DATA LOCAL INPATH '$path'
+         | INTO TABLE $tableName
+         | options('FILEHEADER'='shortField,intField,bigintField,doubleField,stringField,timestampField,decimalField,dateField,charField')
+       """.stripMargin)
+
+    storeLocation + "/default/" + tableName
+  }
+}
+// scalastyle:on println

--- a/examples/flink/pom.xml
+++ b/examples/flink/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.carbondata</groupId>
+    <artifactId>carbondata-parent</artifactId>
+    <version>1.0.0-incubating-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>carbondata-examples-flink</artifactId>
+  <name>Apache CarbonData :: Flink Examples</name>
+
+  <properties>
+    <dev.path>${basedir}/../../dev</dev.path>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-java</artifactId>
+      <version>${flink.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-clients_2.10</artifactId>
+      <version>${flink.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-core</artifactId>
+      <version>0.3.0-incubating</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-io-hdfs</artifactId>
+      <version>0.3.0-incubating</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-hadoop</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-spark</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-examples-spark</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/examples/flink/src/main/scala/org/apache/carbondata/examples/FlinkExample.scala
+++ b/examples/flink/src/main/scala/org/apache/carbondata/examples/FlinkExample.scala
@@ -17,40 +17,46 @@
 
 package org.apache.carbondata.examples
 
+import org.apache.flink.api.java.ExecutionEnvironment
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.mapreduce.Job
 
 import org.apache.carbondata.examples.util.ExampleUtils
 import org.apache.carbondata.hadoop.{CarbonInputFormat, CarbonProjection}
 
-// Read carbondata file by mapreduce job
+// Write carbondata file by spark and read it by flink
 // scalastyle:off println
-object HadoopFileExample {
+object FlinkExample {
 
   def main(args: Array[String]): Unit = {
-    val cc = ExampleUtils.createCarbonContext("HadoopFileExample")
-    ExampleUtils.writeSampleCarbonFile(cc, "carbon1")
+    // write carbondata file by spark
+    val cc = ExampleUtils.createCarbonContext("FlinkExample")
+    val path = ExampleUtils.writeSampleCarbonFile(cc, "carbon1")
 
-    // read two columns
+    // read two columns by flink
     val conf = new Configuration()
     val projection = new CarbonProjection
     projection.addColumn("c1")  // column c1
     projection.addColumn("c3")  // column c3
     CarbonInputFormat.setColumnProjection(conf, projection)
 
-    // read using mapreduce job
-    val sc = cc.sparkContext
-    val input = sc.newAPIHadoopFile(
-      s"${cc.storePath}/default/carbon1",
-      classOf[CarbonInputFormat[Array[Object]]],
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val ds = env.readHadoopFile(
+      new CarbonInputFormat[Array[Object]],
       classOf[Void],
       classOf[Array[Object]],
-      conf
+      path,
+      new Job(conf)
     )
-    val result = input.map(x => x._2.toList).collect
-    result.foreach(x => println(x.mkString(", ")))
 
+    // print result
+    val result = ds.collect()
+    for (i <- 0 until result.size()) {
+      println(result.get(i).f1.mkString(","))
+    }
+
+    // delete carbondata file
     ExampleUtils.cleanSampleCarbonFile(cc, "carbon1")
   }
 }
 // scalastyle:on println
-

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/DataFrameAPIExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/DataFrameAPIExample.scala
@@ -44,7 +44,7 @@ object DataFrameAPIExample {
     // use SQL to read
     cc.sql("SELECT c1, count(c3) FROM carbon1 where c3 > 500 group by c1 limit 10").show
 
-    cc.sql("DROP TABLE IF EXISTS carbon1")
+    ExampleUtils.cleanSampleCarbonFile(cc, "carbon1")
   }
 }
 // scalastyle:on println

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/DatasourceExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/DatasourceExample.scala
@@ -37,5 +37,7 @@ object DatasourceExample {
         | OPTIONS (path '${cc.storePath}/default/table1')
       """.stripMargin)
     sqlContext.sql("SELECT c1, c2, count(*) FROM source WHERE c3 > 100 GROUP BY c1, c2").show
+
+    ExampleUtils.cleanSampleCarbonFile(cc, "table1")
   }
 }

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/DirectSQLExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/DirectSQLExample.scala
@@ -40,5 +40,7 @@ object DirectSQLExample {
         | WHERE c3 > 100
         | GROUP BY c1, c2
       """.stripMargin).show
+
+    ExampleUtils.cleanSampleCarbonFile(cc, "table1")
   }
 }

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/util/ExampleUtils.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/util/ExampleUtils.scala
@@ -56,17 +56,19 @@ object ExampleUtils {
   /**
    * This func will write a sample CarbonData file containing following schema:
    * c1: String, c2: String, c3: Double
+   * Returns the path string of writen table
    */
-  def writeSampleCarbonFile(cc: CarbonContext, tableName: String, numRows: Int = 1000): Unit = {
-    cc.sql(s"DROP TABLE IF EXISTS $tableName")
+  def writeSampleCarbonFile(cc: CarbonContext, tableName: String, numRows: Int = 1000): String = {
     writeDataframe(cc, tableName, numRows, SaveMode.Overwrite)
+    cc.storePath + "/default/" + tableName
   }
 
   /**
    * This func will append data to the CarbonData file
    */
-  def appendSampleCarbonFile(cc: CarbonContext, tableName: String, numRows: Int = 1000): Unit = {
+  def appendSampleCarbonFile(cc: CarbonContext, tableName: String, numRows: Int = 1000): String = {
     writeDataframe(cc, tableName, numRows, SaveMode.Append)
+    cc.storePath + "/default/" + tableName
   }
 
   /**
@@ -89,17 +91,10 @@ object ExampleUtils {
         .option("useKettle", "false")
         .mode(mode)
         .save()
+  }
 
-    // save dataframe directl to carbon file without tempCSV
-    df.write
-      .format("carbondata")
-      .option("tableName", tableName)
-      .option("compress", "true")
-      .option("useKettle", "false")
-      .option("tempCSV", "false")
-      .mode(mode)
-      .save()
-
+  def cleanSampleCarbonFile(cc: CarbonContext, tableName: String): Unit = {
+    cc.sql(s"DROP TABLE IF EXISTS $tableName")
   }
 }
 // scalastyle:on println


### PR DESCRIPTION
Added two example modules:
1. Use Flink to read CarbonData files
2. Use Beam to read CarbonData files
These examples read CarbonData files by using Hadoop InputFormat interface (`CarbonInputFormat`)
